### PR TITLE
networkmanager: Set DHCP timeout to 90s for IPv4

### DIFF
--- a/meta-balena-common/recipes-connectivity/networkmanager/balena-files/NetworkManager.conf
+++ b/meta-balena-common/recipes-connectivity/networkmanager/balena-files/NetworkManager.conf
@@ -8,4 +8,4 @@ hostname-mode=none
 unmanaged-devices=interface-name:balena*;interface-name:resin*;interface-name:br*;type:veth
 
 [connection]
-ipv4.dhcp-timeout=2147483647
+ipv4.dhcp-timeout=90


### PR DESCRIPTION
networkmanager: Set DHCP timeout to 90 seconds instead of infinity for IPv4 

[Issue #2578]

on some routers that do not renew leases properly infinite timeout causes device to loose connectivity completely once the lease expires.
For example a router power cycle may cause this.
90 seconds is default value of dhcp timeout for Debian.

Signed-off-by: Jesse Jämsén <jasse.jamsen@gmail.com>